### PR TITLE
fix: handle insufficient words when generating choices

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -15,6 +15,7 @@ export function shuffle<T>(arr: T[]): T[] {
 
 export function ensureFiveChoices(correct: Word, source: Word[]): Word[] {
   const others = source.filter((w) => w.id !== correct.id);
-  const distractors = shuffle(others).slice(0, Math.max(0, 4));
+  // Pick up to four distractors (less if there aren't enough words left)
+  const distractors = shuffle(others).slice(0, Math.min(4, others.length));
   return shuffle([correct, ...distractors]);
 }


### PR DESCRIPTION
## Summary
- fix choice generator to avoid requesting too many distractors

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1db4e66ec83269797e124947772f5