### PR TITLE
Allow accentless French translations in module 1

### DIFF
--- a/app/module/1/index.tsx
+++ b/app/module/1/index.tsx
@@ -8,7 +8,7 @@ import { useTheme } from "../../../hooks/useTheme";
 import { canPlayRemoteAudio, getPlayableAudioSource, playAudioFileOrTTS } from "../../../lib/audio";
 import { loadWordsLocalOnly, type Word } from "../../../lib/data";
 import { isPinyinAnswerCorrect } from "../../../lib/pinyin";
-import { ensureFiveChoices, pickRandom, shuffle } from "../../../lib/utils";
+import { ensureFiveChoices, pickRandom, shuffle, stripAccents } from "../../../lib/utils";
 
 type HintMode = "hanzi" | "pinyin" | "translation";
 type GameParams = {
@@ -138,7 +138,9 @@ export default function Module1Game() {
 
     if (hintType === "hanzi") {
       // Expect FR + pinyin
-      const frOK = inputFR.trim().toLowerCase() === current.fr.toLowerCase();
+      const frOK =
+        stripAccents(inputFR.trim().toLowerCase()) ===
+        stripAccents(current.fr.toLowerCase());
       if (!frOK) { correct = false; messages.push(`Traduction attendue : "${current.fr}"`); }
       const { ok: pinOK, accentWarning, missingTones, corrected } =
         isPinyinAnswerCorrect(inputPinyin.trim(), current.pinyin);
@@ -153,7 +155,9 @@ export default function Module1Game() {
 
     if (hintType === "pinyin") {
       // Expect FR + choice hanzi (accept multi homophones)
-      const frOK = inputFR.trim().toLowerCase() === current.fr.toLowerCase();
+      const frOK =
+        stripAccents(inputFR.trim().toLowerCase()) ===
+        stripAccents(current.fr.toLowerCase());
       if (!frOK) { correct = false; messages.push(`Traduction attendue : "${current.fr}"`); }
       const isAccepted = selectedId != null && acceptedIds.has(selectedId);
       if (!isAccepted) { correct = false; messages.push("Mauvais caractère choisi."); }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -19,3 +19,7 @@ export function ensureFiveChoices(correct: Word, source: Word[]): Word[] {
   const distractors = shuffle(others).slice(0, Math.min(4, others.length));
   return shuffle([correct, ...distractors]);
 }
+
+export function stripAccents(s: string): string {
+  return s.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+}


### PR DESCRIPTION
## Summary
- accept module 1 French translations even when accents are omitted
- add `stripAccents` utility for accent-insensitive comparison

## Testing
- `npm test` *(fails: Missing script: "test"*)
- `npm run lint` *(no output; possibly due to environment restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68a3377266888326b0797bc976256fda