### PR TITLE
Add navigation links to ResultScreen

### DIFF
--- a/app/module/1/index.tsx
+++ b/app/module/1/index.tsx
@@ -260,11 +260,33 @@ export default function Module1Game() {
             <Text style={{ fontSize: tx(18), color: colors.text }}>{message}</Text>
           </View>
           <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
-            <Link href="/module/1/settings" style={{ color: colors.text }}>
-              ← Paramètres
+            <Link href="/module/1/settings" asChild>
+              <Pressable
+                style={{
+                  backgroundColor: colors.card,
+                  borderColor: colors.border,
+                  borderWidth: 1,
+                  borderRadius: 12,
+                  paddingHorizontal: 12,
+                  paddingVertical: 8,
+                }}
+              >
+                <Text style={{ color: colors.text, fontWeight: "600" }}>← Paramètres</Text>
+              </Pressable>
             </Link>
-            <Link href="/" style={{ color: colors.text }}>
-              Menu principal →
+            <Link href="/" asChild>
+              <Pressable
+                style={{
+                  backgroundColor: colors.card,
+                  borderColor: colors.border,
+                  borderWidth: 1,
+                  borderRadius: 12,
+                  paddingHorizontal: 12,
+                  paddingVertical: 8,
+                }}
+              >
+                <Text style={{ color: colors.text, fontWeight: "600" }}>Menu principal →</Text>
+              </Pressable>
             </Link>
           </View>
         </View>


### PR DESCRIPTION
## Summary
- add links to settings and main menu at bottom of result screen

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a339b07fa88326ac2fa559de4bed36