### PR TITLE
feat: show frDetails in module 1

### DIFF
--- a/app/module/1/index.tsx
+++ b/app/module/1/index.tsx
@@ -313,6 +313,12 @@ export default function Module1Game() {
           {hintText}
         </Text>
 
+        {hintType === "translation" && current.frDetails && (
+          <Text style={{ marginTop: 4, fontSize: tx(16), color: colors.muted }}>
+            {current.frDetails}
+          </Text>
+        )}
+
         {hintType === "pinyin" && !questionDone && (
           <Pressable
             onPress={onPressAudio}

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -7,6 +7,7 @@ export type Word = {
   pinyin: string;   // with tones
   numeric: string;  //  ni3 hao3
   fr: string;
+  frDetails?: string;
   audioUrl?: string;
 };
 


### PR DESCRIPTION
## Summary
- support optional `frDetails` on Word type
- display `frDetails` when asking for French translation

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a3529352d483268c3d4b35f1668e47