### PR TITLE
Handle slash-separated French answers in Module 1

### DIFF
--- a/app/module/1/errors.tsx
+++ b/app/module/1/errors.tsx
@@ -4,6 +4,7 @@ import { ScrollView, Text, View } from "react-native";
 import { ZenButton } from "../../../components/ZenButton";
 import { useTheme } from "../../../hooks/useTheme";
 import { type Word } from "../../../lib/data";
+import { formatFr } from "../../../lib/utils";
 
 export default function ErrorListScreen() {
   const { colors, tx } = useTheme();
@@ -43,7 +44,7 @@ export default function ErrorListScreen() {
               {w.hanzi}
             </Text>
             <Text style={{ fontSize: tx(16), color: colors.text }}>
-              {w.pinyin} · {w.fr}
+              {w.pinyin} · {formatFr(w.fr)}
             </Text>
           </View>
         ))}

--- a/app/module/1/index.tsx
+++ b/app/module/1/index.tsx
@@ -8,7 +8,7 @@ import { useTheme } from "../../../hooks/useTheme";
 import { canPlayRemoteAudio, getPlayableAudioSource, playAudioFileOrTTS } from "../../../lib/audio";
 import { loadWordsLocalOnly, type Word } from "../../../lib/data";
 import { isPinyinAnswerCorrect } from "../../../lib/pinyin";
-import { ensureFiveChoices, pickRandom, shuffle, stripAccents } from "../../../lib/utils";
+import { ensureFiveChoices, pickRandom, shuffle, isFrenchAnswerCorrect, formatFr } from "../../../lib/utils";
 
 type HintMode = "hanzi" | "pinyin" | "translation";
 type GameParams = {
@@ -143,10 +143,8 @@ export default function Module1Game() {
 
     if (hintType === "hanzi") {
       // Expect FR + pinyin
-      const frOK =
-        stripAccents(inputFR.trim().toLowerCase()) ===
-        stripAccents(current.fr.toLowerCase());
-      if (!frOK) { correct = false; messages.push(`Traduction attendue : "${current.fr}"`); }
+      const frOK = isFrenchAnswerCorrect(inputFR, current.fr);
+      if (!frOK) { correct = false; messages.push(`Traduction attendue : "${formatFr(current.fr)}"`); }
       const { ok: pinOK, accentWarning, missingTones, corrected } =
         isPinyinAnswerCorrect(inputPinyin.trim(), current.pinyin);
       if (!pinOK) {
@@ -160,10 +158,8 @@ export default function Module1Game() {
 
     if (hintType === "pinyin") {
       // Expect FR + choice hanzi (accept multi homophones)
-      const frOK =
-        stripAccents(inputFR.trim().toLowerCase()) ===
-        stripAccents(current.fr.toLowerCase());
-      if (!frOK) { correct = false; messages.push(`Traduction attendue : "${current.fr}"`); }
+      const frOK = isFrenchAnswerCorrect(inputFR, current.fr);
+      if (!frOK) { correct = false; messages.push(`Traduction attendue : "${formatFr(current.fr)}"`); }
       const isAccepted = selectedId != null && acceptedIds.has(selectedId);
       if (!isAccepted) { correct = false; messages.push("Mauvais caractère choisi."); }
     }
@@ -199,7 +195,7 @@ export default function Module1Game() {
         .filter(Boolean)
         .join(" / ") || current.hanzi;
 
-    const solutionLine = `Solution — 汉字: ${hanziSolutions} · Pinyin: ${current.pinyin} · FR: ${current.fr}`;
+    const solutionLine = `Solution — 汉字: ${hanziSolutions} · Pinyin: ${current.pinyin} · FR: ${formatFr(current.fr)}`;
     setFeedback([header, ...messages, solutionLine]);
     setShowResult(true);
 
@@ -279,7 +275,7 @@ export default function Module1Game() {
   if (!current) return null;
 
   const hintLabel = hintType === "hanzi" ? "汉字" : hintType === "pinyin" ? "Pinyin" : "Traduction FR";
-  const hintText = hintType === "hanzi" ? current.hanzi : hintType === "pinyin" ? current.pinyin : current.fr;
+  const hintText = hintType === "hanzi" ? current.hanzi : hintType === "pinyin" ? current.pinyin : formatFr(current.fr);
 
   return (
     <View style={{ flex: 1 }}>
@@ -352,7 +348,7 @@ export default function Module1Game() {
           }}
         >
           <Text style={{ fontSize: tx(14), color: colors.muted }}>Traduction (FR)</Text>
-          <FauxTextarea value={questionDone ? current.fr : ""} disabled={questionDone} placeholder="—" />
+          <FauxTextarea value={questionDone ? formatFr(current.fr) : ""} disabled={questionDone} placeholder="—" />
           <TextInput
             value={inputFR}
             onChangeText={setInputFR}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -23,3 +23,16 @@ export function ensureFiveChoices(correct: Word, source: Word[]): Word[] {
 export function stripAccents(s: string): string {
   return s.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
 }
+
+export function isFrenchAnswerCorrect(input: string, expected: string): boolean {
+  const normalize = (str: string) => stripAccents(str.trim().toLowerCase());
+  const expectedParts = expected.split("/").map((part) => normalize(part));
+  const inputNorm = normalize(input).replace(/\s+/g, " ");
+  if (expectedParts.includes(inputNorm)) return true;
+  if (expectedParts.length > 1 && inputNorm === expectedParts.join(" ")) return true;
+  return false;
+}
+
+export function formatFr(expected: string): string {
+  return expected.replace(/\//g, " ");
+}


### PR DESCRIPTION
## Summary
- allow FR answers with multiple options separated by `/`
- display accepted FR translations with spaces instead of `/`

## Testing
- `npm run lint`
- `npx tsc --noEmit` *(fails: TS2367 and TS2322 in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68a3531a9c588326843ed8dc77a40762