### PR TITLE
feat(module1): allow reopening solution popin

### DIFF
--- a/app/module/1/index.tsx
+++ b/app/module/1/index.tsx
@@ -510,11 +510,12 @@ export default function Module1Game() {
       {!questionDone ? (
         <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 8, marginTop: 8 }}>
           <ZenButton title="Valider" onPress={validate} />
-        </View> ) : (
+        </View>
+      ) : (
         <View style={{ flexDirection: "row", gap: 8, marginTop: 8 }}>
+          <ZenButton title="Solution" onPress={() => setShowResult(true)} />
           <ZenButton title={nextButtonTitle} onPress={goNext} />
         </View>
-    
       )}
 
       <View style={{ height: 40 }} />


### PR DESCRIPTION
## Summary
- add Solution button next to Next Question in module 1 game
- enable reopening the solution popin after answering

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a38c1117d4832691831c7e16bcccc7