### PR TITLE
Allow French answers without apostrophes in module 1

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -25,8 +25,11 @@ export function stripAccents(s: string): string {
 }
 
 export function isFrenchAnswerCorrect(input: string, expected: string): boolean {
-  const normalize = (str: string) => stripAccents(str.trim().toLowerCase());
-  const expectedParts = expected.split("/").map((part) => normalize(part));
+  const normalize = (str: string) =>
+    stripAccents(str.trim().toLowerCase().replace(/[\u2019']/g, " "));
+  const expectedParts = expected
+    .split("/")
+    .map((part) => normalize(part).replace(/\s+/g, " "));
   const inputNorm = normalize(input).replace(/\s+/g, " ");
   if (expectedParts.includes(inputNorm)) return true;
   if (expectedParts.length > 1 && inputNorm === expectedParts.join(" ")) return true;


### PR DESCRIPTION
## Summary
- ignore apostrophes when validating French answers so inputs like "s appeler" are accepted

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a38cb54cf0832697ef518efcd990ca