### PR TITLE
Fix card shift when selecting characters in module 1

### DIFF
--- a/app/module/1/index.tsx
+++ b/app/module/1/index.tsx
@@ -476,21 +476,20 @@ export default function Module1Game() {
                 width: "30%" as const,
                 aspectRatio: 1,
                 borderRadius: 12,
-                borderWidth: selected ? 2 : 1,
-                borderColor: selected ? colors.text : colors.border,
+                borderWidth: 2,
                 alignItems: "center" as const,
                 justifyContent: "center" as const,
                 backgroundColor: colors.background,
               };
-              const solutionStyle = isSolution
-                ? { borderColor: colors.accent, borderWidth: 3, backgroundColor: colors.background }
-                : null;
+              let borderColor = colors.border;
+              if (selected) borderColor = colors.text;
+              if (isSolution) borderColor = colors.accent;
               return (
                 <Pressable
                   key={w.id}
                   onPress={() => !questionDone && setSelectedId(w.id)}
                   disabled={questionDone}
-                  style={[baseStyle, solutionStyle]}
+                  style={[baseStyle, { borderColor }]}
                 >
                   <Text style={{ fontSize: tx(36), fontWeight: "800", color: colors.text }}>
                     {w.hanzi}


### PR DESCRIPTION
## Summary
- Keep consistent border width for choice tiles to prevent layout jump when selecting characters

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a44070aaf48326bf94b2a681793cf8