### PR TITLE
fix: enable dictionary filters while scrolling

### DIFF
--- a/app/module/2/index.tsx
+++ b/app/module/2/index.tsx
@@ -263,6 +263,7 @@ export default function Module2Dictionary() {
       renderItem={renderItem}
       ListHeaderComponent={renderHeader}
       stickyHeaderIndices={[0]}
+      keyboardShouldPersistTaps="handled"
       columnWrapperStyle={{ gap: 8 }}
       contentContainerStyle={{ padding: 8, gap: 8 }}
       style={{ flex: 1, backgroundColor: colors.background }}


### PR DESCRIPTION
## Summary
- keep module 2 dictionary filters responsive while scrolling by preserving tap events

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a4424e68fc8326860acebb7416f89b