### PR TITLE
feat: limit question to hint plus single answer

### DIFF
--- a/app/module/1/index.tsx
+++ b/app/module/1/index.tsx
@@ -11,11 +11,13 @@ import { isPinyinAnswerCorrect } from "../../../lib/pinyin";
 import { ensureFiveChoices, pickRandom, shuffle, isFrenchAnswerCorrect, formatFr } from "../../../lib/utils";
 
 type HintMode = "hanzi" | "pinyin" | "translation";
+type AnswerMode = "hanzi" | "pinyin" | "translation";
 type GameParams = {
   series?: string;              // "all" or "1,2,3"
   maxQuestions?: string;        // nombre total de questions
   noRepeatHintType?: "0" | "1"; // from settings
-  types?: string;               // "hanzi,pinyin,translation"
+  types?: string;               // "hanzi,pinyin,translation" for hints
+  answer?: string;              // expected answer element
 };
 
 export default function Module1Game() {
@@ -60,13 +62,21 @@ export default function Module1Game() {
 
   const noRepeatHintType = params.noRepeatHintType === "1";
 
-  // allowed types from settings
+  // answer element from settings
+  const answerType: AnswerMode = useMemo(() => {
+    const a = params.answer;
+    if (a === "hanzi" || a === "pinyin" || a === "translation") return a;
+    return "translation";
+  }, [params.answer]);
+
+  // allowed hint types from settings (cannot include answerType)
   const allowedTypes: HintMode[] = useMemo(() => {
     const raw = (params.types ?? "hanzi,pinyin,translation").split(",").map(s => s.trim()).filter(Boolean);
     const valid = new Set<HintMode>(["hanzi", "pinyin", "translation"]);
-    const arr = raw.filter((v): v is HintMode => valid.has(v as HintMode));
-    return arr.length ? arr : ["hanzi", "pinyin", "translation"];
-  }, [params.types]);
+    const arr = raw.filter((v): v is HintMode => valid.has(v as HintMode) && v !== answerType);
+    const defaults = ["hanzi", "pinyin", "translation"].filter(t => t !== answerType) as HintMode[];
+    return arr.length ? arr : defaults;
+  }, [params.types, answerType]);
 
   // load words & filter by series
   useEffect(() => {
@@ -148,10 +158,15 @@ export default function Module1Game() {
     const messages: string[] = [];
     let correct = true;
 
-    if (hintType === "hanzi") {
-      // Expect FR + pinyin
+    if (answerType === "translation") {
       const frOK = isFrenchAnswerCorrect(inputFR, current.fr);
-      if (!frOK) { correct = false; messages.push(`Traduction attendue : "${formatFr(current.fr)}"`); }
+      if (!frOK) {
+        correct = false;
+        messages.push(`Traduction attendue : "${formatFr(current.fr)}"`);
+      }
+    }
+
+    if (answerType === "pinyin") {
       const { ok: pinOK, accentWarning, missingTones, corrected } =
         isPinyinAnswerCorrect(inputPinyin.trim(), current.pinyin);
       if (!pinOK) {
@@ -163,27 +178,12 @@ export default function Module1Game() {
       }
     }
 
-    if (hintType === "pinyin") {
-      // Expect FR + choice hanzi (accept multi homophones)
-      const frOK = isFrenchAnswerCorrect(inputFR, current.fr);
-      if (!frOK) { correct = false; messages.push(`Traduction attendue : "${formatFr(current.fr)}"`); }
+    if (answerType === "hanzi") {
       const isAccepted = selectedId != null && acceptedIds.has(selectedId);
-      if (!isAccepted) { correct = false; messages.push("Mauvais caractère choisi."); }
-    }
-
-    if (hintType === "translation") {
-      // Expect pinyin + choice hanzi (accept multi homophones)
-      const { ok: pinOK, accentWarning, missingTones, corrected } =
-        isPinyinAnswerCorrect(inputPinyin.trim(), current.pinyin);
-      if (!pinOK) {
+      if (!isAccepted) {
         correct = false;
-        if (missingTones) messages.push("Le pinyin doit inclure les tons (accents ou chiffres).");
-        messages.push(`Pinyin attendu : "${current.pinyin}" (toléré en numérique : "${current.numeric}")`);
-      } else if (accentWarning) {
-        messages.push(`✔ Pinyin correct (numérique). Forme accentuée : "${corrected}".`);
+        messages.push("Mauvais caractère choisi.");
       }
-      const isAccepted = selectedId != null && acceptedIds.has(selectedId);
-      if (!isAccepted) { correct = false; messages.push("Mauvais caractère choisi."); }
     }
 
     // scoring
@@ -381,13 +381,13 @@ export default function Module1Game() {
         </Text>
       </View>
 
-      {/* FR block (FauxTextarea + input) */}
-      {(hintType === "hanzi" || hintType === "pinyin") && (
-        <View
-          style={{
-            backgroundColor: colors.card,
-            borderRadius: 16,
-            padding: 16,
+  {/* FR block (FauxTextarea + input) */}
+  {answerType === "translation" && (
+    <View
+      style={{
+        backgroundColor: colors.card,
+        borderRadius: 16,
+        padding: 16,
             borderWidth: 1,
             borderColor: colors.border,
             gap: 6,
@@ -415,13 +415,13 @@ export default function Module1Game() {
         </View>
       )}
 
-      {/* Pinyin block (FauxTextarea + input) */}
-      {(hintType === "hanzi" || hintType === "translation") && (
-        <View
-          style={{
-            backgroundColor: colors.card,
-            borderRadius: 16,
-            padding: 16,
+  {/* Pinyin block (FauxTextarea + input) */}
+  {answerType === "pinyin" && (
+    <View
+      style={{
+        backgroundColor: colors.card,
+        borderRadius: 16,
+        padding: 16,
             borderWidth: 1,
             borderColor: colors.border,
             gap: 6,
@@ -453,13 +453,13 @@ export default function Module1Game() {
         </View>
       )}
 
-      {/* Choice tiles */}
-      {(hintType === "pinyin" || hintType === "translation") && (
-        <View
-          style={{
-            backgroundColor: colors.card,
-            borderRadius: 16,
-            padding: 16,
+  {/* Choice tiles */}
+  {answerType === "hanzi" && (
+    <View
+      style={{
+        backgroundColor: colors.card,
+        borderRadius: 16,
+        padding: 16,
             borderWidth: 1,
             borderColor: colors.border,
             gap: 6,

--- a/app/module/1/settings.tsx
+++ b/app/module/1/settings.tsx
@@ -12,7 +12,7 @@ export default function Module1Settings() {
   const { colors, tx } = useTheme();
 
   const [words, setWords] = useState<Word[]>([]);
-  const [selectedSeries, setSelectedSeries] = useState<Array<number> | "all">("all");
+  const [selectedSeries, setSelectedSeries] = useState<number[] | "all">("all");
   const [maxQuestions, setMaxQuestions] = useState<number | null>(null);
   const [noRepeatHintType, setNoRepeatHintType] = useState<boolean>(true);
 
@@ -20,6 +20,17 @@ export default function Module1Settings() {
   const [allowHanzi, setAllowHanzi] = useState(true);
   const [allowPinyin, setAllowPinyin] = useState(true);
   const [allowTranslation, setAllowTranslation] = useState(true);
+
+  // Answer element (user will provide this element)
+  type ElementType = "hanzi" | "pinyin" | "translation";
+  const [answerType, setAnswerType] = useState<ElementType>("translation");
+
+  // Whenever answerType changes, ensure corresponding question type is disabled
+  useEffect(() => {
+    if (answerType === "hanzi") setAllowHanzi(false);
+    if (answerType === "pinyin") setAllowPinyin(false);
+    if (answerType === "translation") setAllowTranslation(false);
+  }, [answerType]);
 
   const filteredWords = useMemo(() => {
     return selectedSeries === "all"
@@ -87,6 +98,7 @@ export default function Module1Settings() {
         maxQuestions: String(max),
         noRepeatHintType: noRepeatHintType ? "1" : "0",
         types: types.join(","),
+        answer: answerType,
       },
     });
   }
@@ -202,6 +214,73 @@ export default function Module1Settings() {
         <Switch value={noRepeatHintType} onValueChange={setNoRepeatHintType} />
       </View>
 
+      {/* Answer element */}
+      <View
+        style={{
+          backgroundColor: colors.card,
+          borderRadius: 12,
+          padding: 12,
+          gap: 8,
+          borderWidth: 1,
+          borderColor: colors.border,
+        }}
+      >
+        <Text style={{ fontSize: tx(16), fontWeight: "600", color: colors.text }}>
+          Élément de réponse attendu
+        </Text>
+        <Pressable
+          onPress={() => setAnswerType("translation")}
+          style={{ flexDirection: "row", alignItems: "center", gap: 10, paddingVertical: 6 }}
+        >
+          <View
+            style={{
+              width: 20,
+              height: 20,
+              borderRadius: 4,
+              borderWidth: 2,
+              borderColor: colors.border,
+              backgroundColor: answerType === "translation" ? colors.accent : "transparent",
+            }}
+          />
+          <Text style={{ fontSize: tx(15), color: colors.text }}>Traduction FR</Text>
+        </Pressable>
+        <Pressable
+          onPress={() => setAnswerType("pinyin")}
+          style={{ flexDirection: "row", alignItems: "center", gap: 10, paddingVertical: 6 }}
+        >
+          <View
+            style={{
+              width: 20,
+              height: 20,
+              borderRadius: 4,
+              borderWidth: 2,
+              borderColor: colors.border,
+              backgroundColor: answerType === "pinyin" ? colors.accent : "transparent",
+            }}
+          />
+          <Text style={{ fontSize: tx(15), color: colors.text }}>Pinyin</Text>
+        </Pressable>
+        <Pressable
+          onPress={() => setAnswerType("hanzi")}
+          style={{ flexDirection: "row", alignItems: "center", gap: 10, paddingVertical: 6 }}
+        >
+          <View
+            style={{
+              width: 20,
+              height: 20,
+              borderRadius: 4,
+              borderWidth: 2,
+              borderColor: colors.border,
+              backgroundColor: answerType === "hanzi" ? colors.accent : "transparent",
+            }}
+          />
+          <Text style={{ fontSize: tx(15), color: colors.text }}>汉字 (choix)</Text>
+        </Pressable>
+        <Text style={{ fontSize: tx(12), color: colors.muted }}>
+          L’élément choisi ne pourra pas être utilisé comme indice.
+        </Text>
+      </View>
+
       {/* Types de questions */}
       <View
         style={{
@@ -218,7 +297,14 @@ export default function Module1Settings() {
         </Text>
         <Pressable
           onPress={() => setAllowHanzi((v) => !v)}
-          style={{ flexDirection: "row", alignItems: "center", gap: 10, paddingVertical: 6 }}
+          disabled={answerType === "hanzi"}
+          style={{
+            flexDirection: "row",
+            alignItems: "center",
+            gap: 10,
+            paddingVertical: 6,
+            opacity: answerType === "hanzi" ? 0.4 : 1,
+          }}
         >
           <View
             style={{
@@ -234,7 +320,14 @@ export default function Module1Settings() {
         </Pressable>
         <Pressable
           onPress={() => setAllowPinyin((v) => !v)}
-          style={{ flexDirection: "row", alignItems: "center", gap: 10, paddingVertical: 6 }}
+          disabled={answerType === "pinyin"}
+          style={{
+            flexDirection: "row",
+            alignItems: "center",
+            gap: 10,
+            paddingVertical: 6,
+            opacity: answerType === "pinyin" ? 0.4 : 1,
+          }}
         >
           <View
             style={{
@@ -250,7 +343,14 @@ export default function Module1Settings() {
         </Pressable>
         <Pressable
           onPress={() => setAllowTranslation((v) => !v)}
-          style={{ flexDirection: "row", alignItems: "center", gap: 10, paddingVertical: 6 }}
+          disabled={answerType === "translation"}
+          style={{
+            flexDirection: "row",
+            alignItems: "center",
+            gap: 10,
+            paddingVertical: 6,
+            opacity: answerType === "translation" ? 0.4 : 1,
+          }}
         >
           <View
             style={{
@@ -265,7 +365,7 @@ export default function Module1Settings() {
           <Text style={{ fontSize: tx(15), color: colors.text }}>Traduction FR</Text>
         </Pressable>
         <Text style={{ fontSize: tx(12), color: colors.muted }}>
-          Par défaut : les trois activés.
+          Par défaut : tous les indices sauf l’élément de réponse choisi.
         </Text>
       </View>
 

--- a/app/module/1/settings.tsx
+++ b/app/module/1/settings.tsx
@@ -21,16 +21,25 @@ export default function Module1Settings() {
   const [allowPinyin, setAllowPinyin] = useState(true);
   const [allowTranslation, setAllowTranslation] = useState(true);
 
+  // Option to force a single answer element
+  const [singleAnswer, setSingleAnswer] = useState(false);
+
   // Answer element (user will provide this element)
   type ElementType = "hanzi" | "pinyin" | "translation";
   const [answerType, setAnswerType] = useState<ElementType>("translation");
 
-  // Whenever answerType changes, ensure corresponding question type is disabled
+  // Whenever answerType or mode changes, ensure corresponding question type is disabled
   useEffect(() => {
+    if (!singleAnswer) {
+      setAllowHanzi(true);
+      setAllowPinyin(true);
+      setAllowTranslation(true);
+      return;
+    }
     if (answerType === "hanzi") setAllowHanzi(false);
     if (answerType === "pinyin") setAllowPinyin(false);
     if (answerType === "translation") setAllowTranslation(false);
-  }, [answerType]);
+  }, [singleAnswer, answerType]);
 
   const filteredWords = useMemo(() => {
     return selectedSeries === "all"
@@ -91,16 +100,14 @@ export default function Module1Settings() {
     }
 
     const max = maxQuestions ?? filteredWords.length;
-    router.push({
-      pathname: "/module/1",
-      params: {
-        series: selectedSeries === "all" ? "all" : selectedSeries.join(","),
-        maxQuestions: String(max),
-        noRepeatHintType: noRepeatHintType ? "1" : "0",
-        types: types.join(","),
-        answer: answerType,
-      },
-    });
+    const params: Record<string, string> = {
+      series: selectedSeries === "all" ? "all" : selectedSeries.join(","),
+      maxQuestions: String(max),
+      noRepeatHintType: noRepeatHintType ? "1" : "0",
+      types: types.join(","),
+    };
+    if (singleAnswer) params.answer = answerType;
+    router.push({ pathname: "/module/1", params });
   }
 
   return (
@@ -214,72 +221,93 @@ export default function Module1Settings() {
         <Switch value={noRepeatHintType} onValueChange={setNoRepeatHintType} />
       </View>
 
-      {/* Answer element */}
+      {/* Toggle single answer mode */}
       <View
         style={{
           backgroundColor: colors.card,
           borderRadius: 12,
           padding: 12,
-          gap: 8,
+          flexDirection: "row",
+          alignItems: "center",
+          justifyContent: "space-between",
           borderWidth: 1,
           borderColor: colors.border,
         }}
       >
         <Text style={{ fontSize: tx(16), fontWeight: "600", color: colors.text }}>
-          Élément de réponse attendu
+          Réponse unique
         </Text>
-        <Pressable
-          onPress={() => setAnswerType("translation")}
-          style={{ flexDirection: "row", alignItems: "center", gap: 10, paddingVertical: 6 }}
-        >
-          <View
-            style={{
-              width: 20,
-              height: 20,
-              borderRadius: 4,
-              borderWidth: 2,
-              borderColor: colors.border,
-              backgroundColor: answerType === "translation" ? colors.accent : "transparent",
-            }}
-          />
-          <Text style={{ fontSize: tx(15), color: colors.text }}>Traduction FR</Text>
-        </Pressable>
-        <Pressable
-          onPress={() => setAnswerType("pinyin")}
-          style={{ flexDirection: "row", alignItems: "center", gap: 10, paddingVertical: 6 }}
-        >
-          <View
-            style={{
-              width: 20,
-              height: 20,
-              borderRadius: 4,
-              borderWidth: 2,
-              borderColor: colors.border,
-              backgroundColor: answerType === "pinyin" ? colors.accent : "transparent",
-            }}
-          />
-          <Text style={{ fontSize: tx(15), color: colors.text }}>Pinyin</Text>
-        </Pressable>
-        <Pressable
-          onPress={() => setAnswerType("hanzi")}
-          style={{ flexDirection: "row", alignItems: "center", gap: 10, paddingVertical: 6 }}
-        >
-          <View
-            style={{
-              width: 20,
-              height: 20,
-              borderRadius: 4,
-              borderWidth: 2,
-              borderColor: colors.border,
-              backgroundColor: answerType === "hanzi" ? colors.accent : "transparent",
-            }}
-          />
-          <Text style={{ fontSize: tx(15), color: colors.text }}>汉字 (choix)</Text>
-        </Pressable>
-        <Text style={{ fontSize: tx(12), color: colors.muted }}>
-          L’élément choisi ne pourra pas être utilisé comme indice.
-        </Text>
+        <Switch value={singleAnswer} onValueChange={setSingleAnswer} />
       </View>
+
+      {/* Answer element */}
+      {singleAnswer && (
+        <View
+          style={{
+            backgroundColor: colors.card,
+            borderRadius: 12,
+            padding: 12,
+            gap: 8,
+            borderWidth: 1,
+            borderColor: colors.border,
+          }}
+        >
+          <Text style={{ fontSize: tx(16), fontWeight: "600", color: colors.text }}>
+            Élément de réponse attendu
+          </Text>
+          <Pressable
+            onPress={() => setAnswerType("translation")}
+            style={{ flexDirection: "row", alignItems: "center", gap: 10, paddingVertical: 6 }}
+          >
+            <View
+              style={{
+                width: 20,
+                height: 20,
+                borderRadius: 4,
+                borderWidth: 2,
+                borderColor: colors.border,
+                backgroundColor: answerType === "translation" ? colors.accent : "transparent",
+              }}
+            />
+            <Text style={{ fontSize: tx(15), color: colors.text }}>Traduction FR</Text>
+          </Pressable>
+          <Pressable
+            onPress={() => setAnswerType("pinyin")}
+            style={{ flexDirection: "row", alignItems: "center", gap: 10, paddingVertical: 6 }}
+          >
+            <View
+              style={{
+                width: 20,
+                height: 20,
+                borderRadius: 4,
+                borderWidth: 2,
+                borderColor: colors.border,
+                backgroundColor: answerType === "pinyin" ? colors.accent : "transparent",
+              }}
+            />
+            <Text style={{ fontSize: tx(15), color: colors.text }}>Pinyin</Text>
+          </Pressable>
+          <Pressable
+            onPress={() => setAnswerType("hanzi")}
+            style={{ flexDirection: "row", alignItems: "center", gap: 10, paddingVertical: 6 }}
+          >
+            <View
+              style={{
+                width: 20,
+                height: 20,
+                borderRadius: 4,
+                borderWidth: 2,
+                borderColor: colors.border,
+                backgroundColor: answerType === "hanzi" ? colors.accent : "transparent",
+              }}
+            />
+            <Text style={{ fontSize: tx(15), color: colors.text }}>汉字 (choix)</Text>
+          </Pressable>
+          <Text style={{ fontSize: tx(12), color: colors.muted }}>
+            L’élément choisi ne pourra pas être utilisé comme indice.
+          </Text>
+        </View>
+      )}
 
       {/* Types de questions */}
       <View
@@ -297,13 +325,13 @@ export default function Module1Settings() {
         </Text>
         <Pressable
           onPress={() => setAllowHanzi((v) => !v)}
-          disabled={answerType === "hanzi"}
+          disabled={singleAnswer && answerType === "hanzi"}
           style={{
             flexDirection: "row",
             alignItems: "center",
             gap: 10,
             paddingVertical: 6,
-            opacity: answerType === "hanzi" ? 0.4 : 1,
+            opacity: singleAnswer && answerType === "hanzi" ? 0.4 : 1,
           }}
         >
           <View
@@ -320,13 +348,13 @@ export default function Module1Settings() {
         </Pressable>
         <Pressable
           onPress={() => setAllowPinyin((v) => !v)}
-          disabled={answerType === "pinyin"}
+          disabled={singleAnswer && answerType === "pinyin"}
           style={{
             flexDirection: "row",
             alignItems: "center",
             gap: 10,
             paddingVertical: 6,
-            opacity: answerType === "pinyin" ? 0.4 : 1,
+            opacity: singleAnswer && answerType === "pinyin" ? 0.4 : 1,
           }}
         >
           <View
@@ -343,13 +371,13 @@ export default function Module1Settings() {
         </Pressable>
         <Pressable
           onPress={() => setAllowTranslation((v) => !v)}
-          disabled={answerType === "translation"}
+          disabled={singleAnswer && answerType === "translation"}
           style={{
             flexDirection: "row",
             alignItems: "center",
             gap: 10,
             paddingVertical: 6,
-            opacity: answerType === "translation" ? 0.4 : 1,
+            opacity: singleAnswer && answerType === "translation" ? 0.4 : 1,
           }}
         >
           <View
@@ -365,7 +393,9 @@ export default function Module1Settings() {
           <Text style={{ fontSize: tx(15), color: colors.text }}>Traduction FR</Text>
         </Pressable>
         <Text style={{ fontSize: tx(12), color: colors.muted }}>
-          Par défaut : tous les indices sauf l’élément de réponse choisi.
+          {singleAnswer
+            ? "Par défaut : tous les indices sauf l’élément de réponse choisi."
+            : "Par défaut : tous les types d’indice sont autorisés."}
         </Text>
       </View>
 


### PR DESCRIPTION
## Summary
- allow selecting a single answer element in settings
- sync question types with chosen answer element
- update game logic to expect only the chosen answer element

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a463daa09c8326b86011a900603038