### PR TITLE
Add Hanzi stroke fan component

### DIFF
--- a/app/module/2/[id].tsx
+++ b/app/module/2/[id].tsx
@@ -4,6 +4,7 @@ import { Alert, Pressable, View, Text } from "react-native";
 import { useTheme } from "../../../hooks/useTheme";
 import { loadWordsLocalOnly, type Word } from "../../../lib/data";
 import { canPlayRemoteAudio, getPlayableAudioSource, playAudioFileOrTTS } from "../../../lib/audio";
+import { StrokeFan } from "../../../components/StrokeFan";
 
 export default function WordDetail() {
   const { id } = useLocalSearchParams<{ id: string }>();
@@ -66,6 +67,7 @@ export default function WordDetail() {
         <Text style={{ fontSize: tx(64), color: colors.text, fontWeight: "700" }}>
           {word.hanzi}
         </Text>
+        <StrokeFan char={word.hanzi} />
         <Text style={{ fontSize: tx(24), color: colors.text }}>{word.pinyin}</Text>
         <Text style={{ fontSize: tx(20), color: colors.text }}>{word.fr}</Text>
         <Pressable

--- a/components/StrokeFan.tsx
+++ b/components/StrokeFan.tsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from "react";
+import { View } from "react-native";
+import Svg, { Path } from "react-native-svg";
+import HanziWriter, { type CharacterData } from "hanzi-writer";
+
+type Props = {
+  char: string;
+  size?: number;
+};
+
+async function loadCharacterDataOffline(_char: string): Promise<CharacterData> {
+  // TODO: Implement offline data loader if offline support is required.
+  throw new Error("Offline data loader not implemented");
+}
+
+export const StrokeFan: React.FC<Props> = ({ char, size = 80 }) => {
+  const [strokes, setStrokes] = useState<string[]>([]);
+
+  useEffect(() => {
+    let mounted = true;
+    HanziWriter.loadCharacterData(char)
+      .then((data) => {
+        if (mounted) setStrokes(data.strokes);
+      })
+      .catch(async () => {
+        try {
+          const offline = await loadCharacterDataOffline(char);
+          if (mounted) setStrokes(offline.strokes);
+        } catch {
+          if (mounted) setStrokes([]);
+        }
+      });
+    return () => {
+      mounted = false;
+    };
+  }, [char]);
+
+  if (strokes.length === 0) return null;
+
+  return (
+    <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 8, justifyContent: "center" }}>
+      {strokes.map((_, index) => (
+        <Svg key={index} width={size} height={size} viewBox="0 0 100 100">
+          {strokes.slice(0, index + 1).map((d, i) => (
+            <Path key={i} d={d} stroke="#000" strokeWidth={4} fill="none" />
+          ))}
+        </Svg>
+      ))}
+    </View>
+  );
+};
+

--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
     "expo-audio": "~0.4.8",
     "expo-file-system": "~18.1.11",
     "expo-network": "~7.1.5",
-    "@react-native-async-storage/async-storage": "2.1.2"
+    "@react-native-async-storage/async-storage": "2.1.2",
+    "hanzi-writer": "^3.7.0",
+    "react-native-svg": "^15.12.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
## Summary
- add StrokeFan component that loads stroke data with HanziWriter and renders progressive SVGs
- display StrokeFan beneath characters in module 2 detail screen
- declare hanzi-writer and react-native-svg dependencies

## Testing
- `npm run lint` *(fails: Unable to resolve path to module 'react-native-svg', Unable to resolve path to module 'hanzi-writer')*


------
https://chatgpt.com/codex/tasks/task_e_68a472c2b4c8832682e547551950f138