### PR TITLE
feat(module3): add hanzi writing exercise

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -85,7 +85,7 @@ export default function HomeScreen() {
         <ZenButton title="Cours" onPress={go("/module/4")} />
         <ZenButton title="Dictionnaire" onPress={go("/module/2", "Bravo !")} />
         <ZenButton title="Exercices" onPress={go("/module/1/settings", "Dommage…")} />
-        <ZenButton title="Progression" onPress={go("/module/3")} />
+        <ZenButton title="Écriture" onPress={go("/module/3/settings")} />
       </View>
 
       {/* Footer */}

--- a/app/module/3/index.tsx
+++ b/app/module/3/index.tsx
@@ -1,0 +1,88 @@
+import { useLocalSearchParams, useRouter } from "expo-router";
+import React, { useEffect, useState } from "react";
+import { Alert, Text, View } from "react-native";
+import { HanziWriterQuiz } from "../../../components/HanziWriterQuiz";
+import { ZenButton } from "../../../components/ZenButton";
+import { useTheme } from "../../../hooks/useTheme";
+import { loadWordsLocalOnly, type Word } from "../../../lib/data";
+import { shuffle } from "../../../lib/utils";
+
+type Params = {
+  series?: string;
+  maxQuestions?: string;
+};
+
+export default function Module3Game() {
+  const { colors, tx } = useTheme();
+  const params = useLocalSearchParams<Params>();
+  const router = useRouter();
+
+  const [words, setWords] = useState<Word[]>([]);
+  const [index, setIndex] = useState(0);
+  const [completed, setCompleted] = useState(false);
+
+  useEffect(() => {
+    loadWordsLocalOnly()
+      .then((all) => {
+        let filtered = all;
+        if (params.series && params.series !== "all") {
+          const set = new Set(params.series.split(",").map((s) => Number(s)));
+          filtered = all.filter((w) => set.has(w.series ?? -1));
+        }
+        if (filtered.length === 0) {
+          Alert.alert("Sélection vide", "Aucun caractère trouvé.");
+        }
+        const max = params.maxQuestions ? Math.min(filtered.length, Number(params.maxQuestions)) : filtered.length;
+        const list = shuffle(filtered).slice(0, max);
+        setWords(list);
+      })
+      .catch(() => Alert.alert("Erreur", "Impossible de charger les mots."));
+  }, [params.series, params.maxQuestions]);
+
+  const current = words[index];
+
+  function handleComplete() {
+    setCompleted(true);
+  }
+
+  function next() {
+    if (index + 1 >= words.length) {
+      router.replace("/module/3/settings");
+    } else {
+      setIndex((i) => i + 1);
+      setCompleted(false);
+    }
+  }
+
+  if (!current) {
+    return (
+      <View style={{ flex: 1, alignItems: "center", justifyContent: "center", backgroundColor: colors.background }}>
+        <Text style={{ color: colors.text, fontSize: tx(16) }}>Chargement...</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={{ flex: 1, backgroundColor: colors.background, padding: 20 }}>
+      <Text
+        style={{
+          fontSize: tx(18),
+          fontWeight: "700",
+          color: colors.text,
+          textAlign: "center",
+          marginBottom: 10,
+        }}
+      >
+        Écris le caractère
+      </Text>
+      <View style={{ flex: 1 }}>
+        <HanziWriterQuiz char={current.hanzi} onComplete={handleComplete} />
+      </View>
+      {completed && (
+        <View style={{ marginTop: 12 }}>
+          <ZenButton title={index + 1 >= words.length ? "Terminer" : "Suivant"} onPress={next} />
+        </View>
+      )}
+    </View>
+  );
+}

--- a/app/module/3/settings.tsx
+++ b/app/module/3/settings.tsx
@@ -1,0 +1,107 @@
+import { Link, useRouter } from "expo-router";
+import { useEffect, useMemo, useState } from "react";
+import { Alert, Pressable, ScrollView, Text, TextInput, View } from "react-native";
+import { ZenButton } from "../../../components/ZenButton";
+import { useTheme } from "../../../hooks/useTheme";
+import { loadWordsLocalOnly, type Word } from "../../../lib/data";
+
+interface SeriesOption { value: number | "all"; label: string }
+
+export default function Module3Settings() {
+  const router = useRouter();
+  const { colors, tx } = useTheme();
+
+  const [words, setWords] = useState<Word[]>([]);
+  const [selectedSeries, setSelectedSeries] = useState<number[] | "all">("all");
+  const [maxQuestions, setMaxQuestions] = useState<number | null>(null);
+
+  useEffect(() => {
+    loadWordsLocalOnly()
+      .then(setWords)
+      .catch(() => Alert.alert("Erreur", "Impossible de charger les mots."));
+  }, []);
+
+  const series = useMemo<SeriesOption[]>(() => {
+    const set = new Set<number>();
+    words.forEach(w => typeof w.series === "number" && set.add(w.series));
+    const arr = Array.from(set).sort((a,b) => a-b).map(n => ({ value: n, label: `Série ${n}` }));
+    return [{ value: "all", label: "Toutes les séries" }, ...arr];
+  }, [words]);
+
+  const filteredWords = useMemo(() => {
+    return selectedSeries === "all"
+      ? words
+      : words.filter(w => selectedSeries.includes(w.series ?? -1));
+  }, [words, selectedSeries]);
+
+  useEffect(() => {
+    setMaxQuestions(filteredWords.length);
+  }, [filteredWords.length]);
+
+  function toggleSeries(opt: SeriesOption) {
+    if (opt.value === "all") { setSelectedSeries("all"); return; }
+    if (selectedSeries === "all") setSelectedSeries([opt.value as number]);
+    else {
+      const set = new Set(selectedSeries);
+      if (set.has(opt.value as number)) set.delete(opt.value as number); else set.add(opt.value as number);
+      const arr = Array.from(set).sort((a,b) => a-b);
+      setSelectedSeries(arr.length ? arr : "all");
+    }
+  }
+
+  function startGame() {
+    if (filteredWords.length === 0) {
+      Alert.alert("Sélection insuffisante", "Choisis au moins une série.");
+      return;
+    }
+    const max = maxQuestions ?? filteredWords.length;
+    const params = {
+      series: selectedSeries === "all" ? "all" : selectedSeries.join(","),
+      maxQuestions: String(max)
+    };
+    router.push({ pathname: "/module/3", params });
+  }
+
+  return (
+    <ScrollView
+      style={{ flex:1, backgroundColor: colors.background }}
+      contentContainerStyle={{ padding:20, gap:16 }}
+    >
+      <Text style={{ fontSize: tx(20), fontWeight: "700", color: colors.text }}>
+        Paramètres de la partie
+      </Text>
+
+      <View style={{ backgroundColor: colors.card, borderRadius:12, padding:12, gap:8, borderWidth:1, borderColor: colors.border }}>
+        <Text style={{ fontSize: tx(16), fontWeight: "600", color: colors.text }}>Séries</Text>
+        {series.map(opt => {
+          const selected = selectedSeries === "all" ? opt.value === "all" : opt.value !== "all" && selectedSeries.includes(opt.value as number);
+          return (
+            <Pressable key={String(opt.value)} onPress={() => toggleSeries(opt)} style={{ flexDirection:"row", alignItems:"center", gap:10, paddingVertical:6 }}>
+              <View style={{ width:20, height:20, borderRadius:4, borderWidth:2, borderColor: colors.border, backgroundColor: selected ? colors.accent : "transparent" }} />
+              <Text style={{ fontSize: tx(15), color: colors.text }}>{opt.label}</Text>
+            </Pressable>
+          );
+        })}
+      </View>
+
+      <View style={{ backgroundColor: colors.card, borderRadius:12, padding:12, gap:8, borderWidth:1, borderColor: colors.border }}>
+        <Text style={{ fontSize: tx(16), fontWeight: "600", color: colors.text }}>Nombre max de questions</Text>
+        <TextInput
+          keyboardType="numeric"
+          value={maxQuestions?.toString() ?? ""}
+          onChangeText={t => setMaxQuestions(t ? Number(t) : null)}
+          style={{ backgroundColor: colors.background, paddingHorizontal:12, paddingVertical:6, borderRadius:8, borderWidth:1, borderColor: colors.border, color: colors.text }}
+        />
+        <Text style={{ fontSize: tx(12), color: colors.muted }}>Max : {filteredWords.length}</Text>
+      </View>
+
+      <ZenButton title="Démarrer la partie" onPress={startGame} />
+
+      <Link href="/" asChild>
+        <Pressable style={{ paddingVertical:10, alignItems:"center" }}>
+          <Text style={{ color: colors.muted, fontSize: tx(14) }}>← Retour menu</Text>
+        </Pressable>
+      </Link>
+    </ScrollView>
+  );
+}

--- a/components/HanziWriterQuiz.tsx
+++ b/components/HanziWriterQuiz.tsx
@@ -1,0 +1,26 @@
+import React, { useMemo } from 'react';
+import { WebView } from 'react-native-webview';
+
+interface Props {
+  char: string;
+  onComplete?: () => void;
+}
+
+export function HanziWriterQuiz({ char, onComplete }: Props) {
+  const html = useMemo(() => {
+    return `\n<!DOCTYPE html>\n<html>\n  <head>\n    <meta charset=\"utf-8\" />\n    <style>html,body,#target{margin:0;padding:0;height:100%;display:flex;justify-content:center;align-items:center;background-color:transparent;}</style>\n    <script src=\"https://cdn.jsdelivr.net/npm/hanzi-writer@2.2.2/dist/hanzi-writer.min.js\"></script>\n  </head>\n  <body>\n    <div id=\"target\"></div>\n    <script>\n      var writer = HanziWriter.create('target', ${JSON.stringify(char)}, {\n        width: 300,\n        height: 300,\n        showCharacter: false,\n        showOutline: false,\n        showHintAfterMisses: 1,\n        highlightOnComplete: false,\n        padding: 5\n      });\n      writer.quiz({\n        onComplete: function() {\n          window.ReactNativeWebView.postMessage('complete');\n        }\n      });\n    </script>\n  </body>\n</html>`;
+  }, [char]);
+
+  return (
+    <WebView
+      originWhitelist={["*"]}
+      source={{ html }}
+      onMessage={(e) => {
+        if (e.nativeEvent.data === 'complete') {
+          onComplete?.();
+        }
+      }}
+      style={{ backgroundColor: 'transparent' }}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- add HanziWriterQuiz component using WebView
- create module 3 settings and game pages for writing practice
- link writing exercise from home screen

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: expo: not found)*
- `npx expo --version` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a473e9820483269340a4dc240488ca