### PR TITLE
feat(module3): add configurable hints and scoring

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -85,7 +85,7 @@ export default function HomeScreen() {
         <ZenButton title="Cours" onPress={go("/module/4")} />
         <ZenButton title="Dictionnaire" onPress={go("/module/2", "Bravo !")} />
         <ZenButton title="Exercices" onPress={go("/module/1/settings", "Dommage…")} />
-        <ZenButton title="Progression" onPress={go("/module/3")} />
+        <ZenButton title="Écriture" onPress={go("/module/3/settings")} />
       </View>
 
       {/* Footer */}

--- a/app/module/3/index.tsx
+++ b/app/module/3/index.tsx
@@ -1,0 +1,172 @@
+import { useLocalSearchParams, useRouter } from "expo-router";
+import React, { useEffect, useRef, useState } from "react";
+import { Alert, Text, View } from "react-native";
+import { HanziWriterQuiz } from "../../../components/HanziWriterQuiz";
+import { ZenButton } from "../../../components/ZenButton";
+import { useTheme } from "../../../hooks/useTheme";
+import { loadWordsLocalOnly, type Word } from "../../../lib/data";
+import { shuffle } from "../../../lib/utils";
+
+type Params = {
+  series?: string;
+  maxQuestions?: string;
+  showOutline?: string;
+  showHintAfterMisses?: string;
+  scoreMode?: string;
+  maxHints?: string;
+};
+
+export default function Module3Game() {
+  const { colors, tx } = useTheme();
+  const params = useLocalSearchParams<Params>();
+  const router = useRouter();
+
+  const [words, setWords] = useState<Word[]>([]);
+  const [index, setIndex] = useState(0);
+  const [completed, setCompleted] = useState(false);
+  const [finished, setFinished] = useState(false);
+  const [score, setScore] = useState(0);
+  const questionLost = useRef(false);
+
+  useEffect(() => {
+    loadWordsLocalOnly()
+      .then((all) => {
+        let filtered = all;
+        if (params.series && params.series !== "all") {
+          const set = new Set(params.series.split(",").map((s) => Number(s)));
+          filtered = all.filter((w) => set.has(w.series ?? -1));
+        }
+        if (filtered.length === 0) {
+          Alert.alert("Sélection vide", "Aucun caractère trouvé.");
+        }
+        const max = params.maxQuestions ? Math.min(filtered.length, Number(params.maxQuestions)) : filtered.length;
+        const list = shuffle(filtered).slice(0, max);
+        setWords(list);
+      })
+      .catch(() => Alert.alert("Erreur", "Impossible de charger les mots."));
+  }, [params.series, params.maxQuestions]);
+
+  const current = words[index];
+
+  const showOutline = params.showOutline !== "0";
+  const showHintAfterMisses = params.showHintAfterMisses ? Number(params.showHintAfterMisses) : 3;
+  const scoreMode = params.scoreMode === "1";
+  const maxHints = params.maxHints ? Number(params.maxHints) : 3;
+
+  function handleComplete() {
+    if (scoreMode && !questionLost.current) {
+      setScore((s) => s + 1);
+    }
+    questionLost.current = false;
+    setCompleted(true);
+  }
+
+  function handleFail() {
+    if (scoreMode) {
+      questionLost.current = true;
+      setCompleted(true);
+    }
+  }
+
+  function next() {
+    if (index + 1 >= words.length) {
+      setFinished(true);
+    } else {
+      setIndex((i) => i + 1);
+      setCompleted(false);
+      questionLost.current = false;
+    }
+  }
+
+  if (!current && !finished) {
+    return (
+      <View style={{ flex: 1, alignItems: "center", justifyContent: "center", backgroundColor: colors.background }}>
+        <Text style={{ color: colors.text, fontSize: tx(16) }}>Chargement...</Text>
+      </View>
+    );
+  }
+
+  if (finished) {
+    return (
+      <View style={{ flex: 1, alignItems: "center", justifyContent: "center", backgroundColor: colors.background, padding: 20 }}>
+        <Text
+          style={{
+            fontSize: tx(20),
+            fontWeight: "700",
+            color: colors.text,
+            textAlign: "center",
+            marginBottom: 20,
+          }}
+        >
+          Partie terminée !
+        </Text>
+        {scoreMode && (
+          <Text style={{ fontSize: tx(16), color: colors.text, marginBottom: 20 }}>{`Score : ${score}/${words.length}`}</Text>
+        )}
+        <ZenButton title="Retour aux paramètres" onPress={() => router.replace("/module/3/settings")} />
+      </View>
+    );
+  }
+
+  return (
+    <View style={{ flex: 1, backgroundColor: colors.background, padding: 20 }}>
+      {scoreMode && (
+        <Text
+          style={{
+            fontSize: tx(16),
+            fontWeight: "700",
+            color: colors.text,
+            textAlign: "center",
+            marginBottom: 4,
+          }}
+        >
+          {`Score : ${score}/${words.length}`}
+        </Text>
+      )}
+      <Text
+        style={{
+          fontSize: tx(16),
+          fontWeight: "700",
+          color: colors.text,
+          textAlign: "center",
+          marginBottom: 4,
+        }}
+      >
+        Question {index + 1}/{words.length}
+      </Text>
+      <Text
+        style={{
+          fontSize: tx(18),
+          fontWeight: "700",
+          color: colors.text,
+          textAlign: "center",
+          marginBottom: 10,
+        }}
+      >
+        Écris le caractère
+      </Text>
+      <View style={{ flex: 1 }}>
+        <HanziWriterQuiz
+          char={current.hanzi}
+          showOutline={showOutline}
+          showHintAfterMisses={showHintAfterMisses}
+          maxMistakes={scoreMode ? maxHints : undefined}
+          onComplete={handleComplete}
+          onFail={handleFail}
+        />
+      </View>
+      <View style={{ marginTop: 12 }}>
+        <Text style={{ color: colors.text, fontSize: tx(16), textAlign: "center" }}>{current.pinyin}</Text>
+        <Text style={{ color: colors.text, fontSize: tx(16), textAlign: "center" }}>{current.fr}</Text>
+        {current.frDetails && (
+          <Text style={{ color: colors.text, fontSize: tx(14), textAlign: "center" }}>{current.frDetails}</Text>
+        )}
+      </View>
+      {completed && (
+        <View style={{ marginTop: 12 }}>
+          <ZenButton title={index + 1 >= words.length ? "Terminer" : "Question suivante"} onPress={next} />
+        </View>
+      )}
+    </View>
+  );
+}

--- a/app/module/3/settings.tsx
+++ b/app/module/3/settings.tsx
@@ -1,0 +1,150 @@
+import { Link, useRouter } from "expo-router";
+import { useEffect, useMemo, useState } from "react";
+import { Alert, Pressable, ScrollView, Text, TextInput, View } from "react-native";
+import { ZenButton } from "../../../components/ZenButton";
+import { useTheme } from "../../../hooks/useTheme";
+import { loadWordsLocalOnly, type Word } from "../../../lib/data";
+
+interface SeriesOption { value: number | "all"; label: string }
+
+export default function Module3Settings() {
+  const router = useRouter();
+  const { colors, tx } = useTheme();
+
+  const [words, setWords] = useState<Word[]>([]);
+  const [selectedSeries, setSelectedSeries] = useState<number[] | "all">("all");
+  const [maxQuestions, setMaxQuestions] = useState<number | null>(null);
+  const [showOutline, setShowOutline] = useState(true);
+  const [showHintAfterMisses, setShowHintAfterMisses] = useState(3);
+  const [scoreMode, setScoreMode] = useState(false);
+  const [maxHints, setMaxHints] = useState(3);
+
+  useEffect(() => {
+    loadWordsLocalOnly()
+      .then(setWords)
+      .catch(() => Alert.alert("Erreur", "Impossible de charger les mots."));
+  }, []);
+
+  const series = useMemo<SeriesOption[]>(() => {
+    const set = new Set<number>();
+    words.forEach(w => typeof w.series === "number" && set.add(w.series));
+    const arr = Array.from(set).sort((a,b) => a-b).map(n => ({ value: n, label: `Série ${n}` }));
+    return [{ value: "all", label: "Toutes les séries" }, ...arr];
+  }, [words]);
+
+  const filteredWords = useMemo(() => {
+    return selectedSeries === "all"
+      ? words
+      : words.filter(w => selectedSeries.includes(w.series ?? -1));
+  }, [words, selectedSeries]);
+
+  useEffect(() => {
+    setMaxQuestions(filteredWords.length);
+  }, [filteredWords.length]);
+
+  function toggleSeries(opt: SeriesOption) {
+    if (opt.value === "all") { setSelectedSeries("all"); return; }
+    if (selectedSeries === "all") setSelectedSeries([opt.value as number]);
+    else {
+      const set = new Set(selectedSeries);
+      if (set.has(opt.value as number)) set.delete(opt.value as number); else set.add(opt.value as number);
+      const arr = Array.from(set).sort((a,b) => a-b);
+      setSelectedSeries(arr.length ? arr : "all");
+    }
+  }
+
+  function startGame() {
+    if (filteredWords.length === 0) {
+      Alert.alert("Sélection insuffisante", "Choisis au moins une série.");
+      return;
+    }
+    const max = maxQuestions ?? filteredWords.length;
+    const params = {
+      series: selectedSeries === "all" ? "all" : selectedSeries.join(","),
+      maxQuestions: String(max),
+      showOutline: showOutline ? "1" : "0",
+      showHintAfterMisses: String(showHintAfterMisses),
+      scoreMode: scoreMode ? "1" : "0",
+      maxHints: String(maxHints)
+    };
+    router.push({ pathname: "/module/3", params });
+  }
+
+  return (
+    <ScrollView
+      style={{ flex:1, backgroundColor: colors.background }}
+      contentContainerStyle={{ padding:20, gap:16 }}
+    >
+      <Text style={{ fontSize: tx(20), fontWeight: "700", color: colors.text }}>
+        Paramètres de la partie
+      </Text>
+
+      <View style={{ backgroundColor: colors.card, borderRadius:12, padding:12, gap:8, borderWidth:1, borderColor: colors.border }}>
+        <Text style={{ fontSize: tx(16), fontWeight: "600", color: colors.text }}>Séries</Text>
+        {series.map(opt => {
+          const selected = selectedSeries === "all" ? opt.value === "all" : opt.value !== "all" && selectedSeries.includes(opt.value as number);
+          return (
+            <Pressable key={String(opt.value)} onPress={() => toggleSeries(opt)} style={{ flexDirection:"row", alignItems:"center", gap:10, paddingVertical:6 }}>
+              <View style={{ width:20, height:20, borderRadius:4, borderWidth:2, borderColor: colors.border, backgroundColor: selected ? colors.accent : "transparent" }} />
+              <Text style={{ fontSize: tx(15), color: colors.text }}>{opt.label}</Text>
+            </Pressable>
+          );
+        })}
+      </View>
+
+      <View style={{ backgroundColor: colors.card, borderRadius:12, padding:12, gap:8, borderWidth:1, borderColor: colors.border }}>
+        <Text style={{ fontSize: tx(16), fontWeight: "600", color: colors.text }}>Nombre max de questions</Text>
+        <TextInput
+          keyboardType="numeric"
+          value={maxQuestions?.toString() ?? ""}
+          onChangeText={t => setMaxQuestions(t ? Number(t) : null)}
+          style={{ backgroundColor: colors.background, paddingHorizontal:12, paddingVertical:6, borderRadius:8, borderWidth:1, borderColor: colors.border, color: colors.text }}
+        />
+        <Text style={{ fontSize: tx(12), color: colors.muted }}>Max : {filteredWords.length}</Text>
+      </View>
+
+      <View style={{ backgroundColor: colors.card, borderRadius:12, padding:12, gap:8, borderWidth:1, borderColor: colors.border }}>
+        <Text style={{ fontSize: tx(16), fontWeight: "600", color: colors.text }}>Options Hanzi Writer</Text>
+        <Pressable onPress={() => setShowOutline(o => !o)} style={{ flexDirection:"row", alignItems:"center", gap:10, paddingVertical:6 }}>
+          <View style={{ width:20, height:20, borderRadius:4, borderWidth:2, borderColor: colors.border, backgroundColor: showOutline ? colors.accent : "transparent" }} />
+          <Text style={{ fontSize: tx(15), color: colors.text }}>Afficher le contour</Text>
+        </Pressable>
+        <View style={{ gap:4 }}>
+          <Text style={{ fontSize: tx(15), color: colors.text }}>Indice après erreurs</Text>
+          <TextInput
+            keyboardType="numeric"
+            value={showHintAfterMisses.toString()}
+            onChangeText={t => setShowHintAfterMisses(t ? Number(t) : 0)}
+            style={{ backgroundColor: colors.background, paddingHorizontal:12, paddingVertical:6, borderRadius:8, borderWidth:1, borderColor: colors.border, color: colors.text }}
+          />
+        </View>
+      </View>
+
+      <View style={{ backgroundColor: colors.card, borderRadius:12, padding:12, gap:8, borderWidth:1, borderColor: colors.border }}>
+        <Pressable onPress={() => setScoreMode(m => !m)} style={{ flexDirection:"row", alignItems:"center", gap:10, paddingVertical:6 }}>
+          <View style={{ width:20, height:20, borderRadius:4, borderWidth:2, borderColor: colors.border, backgroundColor: scoreMode ? colors.accent : "transparent" }} />
+          <Text style={{ fontSize: tx(15), color: colors.text }}>Mode score</Text>
+        </Pressable>
+        {scoreMode && (
+          <View style={{ gap:4 }}>
+            <Text style={{ fontSize: tx(15), color: colors.text }}>Indices max avant échec</Text>
+            <TextInput
+              keyboardType="numeric"
+              value={maxHints.toString()}
+              onChangeText={t => setMaxHints(t ? Number(t) : 0)}
+              style={{ backgroundColor: colors.background, paddingHorizontal:12, paddingVertical:6, borderRadius:8, borderWidth:1, borderColor: colors.border, color: colors.text }}
+            />
+          </View>
+        )}
+      </View>
+
+      <ZenButton title="Démarrer la partie" onPress={startGame} />
+
+      <Link href="/" asChild>
+        <Pressable style={{ paddingVertical:10, alignItems:"center" }}>
+          <Text style={{ color: colors.muted, fontSize: tx(14) }}>← Retour menu</Text>
+        </Pressable>
+      </Link>
+    </ScrollView>
+  );
+}

--- a/components/HanziWriterQuiz.tsx
+++ b/components/HanziWriterQuiz.tsx
@@ -1,0 +1,39 @@
+import React, { useMemo } from 'react';
+import { WebView } from 'react-native-webview';
+
+interface Props {
+  char: string;
+  showOutline?: boolean;
+  showHintAfterMisses?: number;
+  maxMistakes?: number;
+  onComplete?: () => void;
+  onFail?: () => void;
+}
+
+export function HanziWriterQuiz({
+  char,
+  showOutline = true,
+  showHintAfterMisses = 3,
+  maxMistakes,
+  onComplete,
+  onFail,
+}: Props) {
+  const html = useMemo(() => {
+    return `\n<!DOCTYPE html>\n<html>\n  <head>\n    <meta charset=\"utf-8\" />\n    <style>html,body,#target{margin:0;padding:0;height:100%;display:flex;justify-content:center;align-items:center;background-color:transparent;}</style>\n    <script src=\"https://cdn.jsdelivr.net/npm/hanzi-writer@2.2.2/dist/hanzi-writer.min.js\"></script>\n  </head>\n  <body>\n    <div id=\"target\"></div>\n    <script>\n      var misses = 0;\n      var maxMistakes = ${maxMistakes ?? 'null'};\n      var writer = HanziWriter.create('target', ${JSON.stringify(char)}, {\n        width: 300,\n        height: 300,\n        showCharacter: false,\n        showOutline: ${showOutline},\n        showHintAfterMisses: ${showHintAfterMisses},\n        highlightOnComplete: false,\n        padding: 5\n      });\n      writer.quiz({\n        onMistake: function() {\n          misses++;\n          if (maxMistakes && misses >= maxMistakes) {\n            window.ReactNativeWebView.postMessage('fail');\n          }\n        },\n        onComplete: function() {\n          window.ReactNativeWebView.postMessage('complete');\n        }\n      });\n    </script>\n  </body>\n</html>`;
+  }, [char, showOutline, showHintAfterMisses, maxMistakes]);
+
+  return (
+    <WebView
+      originWhitelist={["*"]}
+      source={{ html }}
+      onMessage={(e) => {
+        if (e.nativeEvent.data === 'complete') {
+          onComplete?.();
+        } else if (e.nativeEvent.data === 'fail') {
+          onFail?.();
+        }
+      }}
+      style={{ backgroundColor: 'transparent' }}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- allow configuring outline, hint delay, and scoring in module 3 settings
- track failures and emit score in HanziWriterQuiz and game screen

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npx expo --version`


------
https://chatgpt.com/codex/tasks/task_e_68a473e9820483269340a4dc240488ca