### PR TITLE
feat(module3): improve writing exercise interactions

### DIFF
--- a/app/module/3/index.tsx
+++ b/app/module/3/index.tsx
@@ -193,6 +193,19 @@ export default function Module3Game() {
           onFail={handleFail}
         />
       </View>
+      {completed && (
+        <Text
+          style={{
+            textAlign: "center",
+            color: questionLost.current ? colors.text : colors.accent,
+            fontSize: tx(16),
+            marginTop: 12,
+            marginBottom: 8,
+          }}
+        >
+          {questionLost.current ? "Dommage..." : "Bravo !"}
+        </Text>
+      )}
       <View
         style={{
           flexDirection: "row",
@@ -214,25 +227,29 @@ export default function Module3Game() {
         >
           <Text style={{ color: colors.text, fontSize: tx(14) }}>Solution</Text>
         </Pressable>
-        <Pressable
-          onPress={restart}
-          style={{
-            paddingHorizontal: 12,
-            paddingVertical: 8,
-            borderRadius: 8,
-            borderWidth: 1,
-            borderColor: colors.border,
-            backgroundColor: colors.card,
-          }}
-        >
-          <Text style={{ color: colors.text, fontSize: tx(14) }}>Recommencer</Text>
-        </Pressable>
+        {!scoreMode && (
+          <Pressable
+            onPress={restart}
+            style={{
+              paddingHorizontal: 12,
+              paddingVertical: 8,
+              borderRadius: 8,
+              borderWidth: 1,
+              borderColor: colors.border,
+              backgroundColor: colors.card,
+            }}
+          >
+            <Text style={{ color: colors.text, fontSize: tx(14) }}>Recommencer</Text>
+          </Pressable>
+        )}
       </View>
-      {completed && (
-        <View style={{ marginTop: 12 }}>
-          <ZenButton title={index + 1 >= words.length ? "Terminer" : "Question suivante"} onPress={next} />
-        </View>
-      )}
+      <View style={{ marginTop: 12 }}>
+        <ZenButton
+          title={index + 1 >= words.length ? "Terminer" : "Question suivante"}
+          onPress={next}
+          disabled={!completed}
+        />
+      </View>
     </View>
   );
 }

--- a/app/module/3/settings.tsx
+++ b/app/module/3/settings.tsx
@@ -27,6 +27,13 @@ export default function Module3Settings() {
       .catch(() => Alert.alert("Erreur", "Impossible de charger les mots."));
   }, []);
 
+  // Ensure at least one info (pinyin or translation) is displayed
+  useEffect(() => {
+    if (!showPinyin && !showTranslation) {
+      setShowTranslation(true);
+    }
+  }, [showPinyin, showTranslation]);
+
   const series = useMemo<SeriesOption[]>(() => {
     const set = new Set<number>();
     words.forEach(w => typeof w.series === "number" && set.add(w.series));


### PR DESCRIPTION
## Summary
- ensure either pinyin or translation is displayed in module 3 settings
- show bravo/dommage message and keep next question button visible but disabled until answered
- hide restart button in score mode

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6fe850ddc8326a141ec95fde29f54