### PR TITLE
Add pinyinDetails support for modules 1 and 3

### DIFF
--- a/app/module/1/index.tsx
+++ b/app/module/1/index.tsx
@@ -449,6 +449,12 @@ export default function Module1Game() {
           </Text>
         )}
 
+        {hintType === "pinyin" && current.pinyinDetails && (
+          <Text style={{ marginTop: 4, fontSize: tx(16), color: colors.muted }}>
+            {current.pinyinDetails}
+          </Text>
+        )}
+
         {hintType === "pinyin" && !questionDone && (
           <Pressable
             onPress={onPressAudio}

--- a/app/module/3/index.tsx
+++ b/app/module/3/index.tsx
@@ -245,6 +245,11 @@ export default function Module3Game() {
             {current.pinyin}
           </Text>
         )}
+        {showPinyin && current.pinyinDetails && (
+          <Text style={{ color: colors.text, fontSize: tx(14), textAlign: "center" }}>
+            {current.pinyinDetails}
+          </Text>
+        )}
         {showTranslation && (
           <Text style={{ color: colors.text, fontSize: tx(16), textAlign: "center" }}>
             {current.fr}

--- a/constants/words.json
+++ b/constants/words.json
@@ -17,8 +17,8 @@
   { "id": "16", "series": 2, "hanzi": "人", "pinyin": "rén", "numeric": "ren2", "fr": "personne" },
   { "id": "17", "series": 2, "hanzi": "日", "pinyin": "rì", "numeric": "ri4", "fr": "soleil/jour" },
   { "id": "18", "series": 2, "hanzi": "是", "pinyin": "shì", "numeric": "shi4", "fr": "être" },
-  { "id": "19", "series": 2, "hanzi": "他", "pinyin": "tā","pinyinDetail":"masculin", "numeric": "ta1", "fr": "il" },
-  { "id": "20", "series": 2, "hanzi": "她", "pinyin": "tā","pinyinDetail":"feminin", "numeric": "ta1", "fr": "elle" },
+  { "id": "19", "series": 2, "hanzi": "他", "pinyin": "tā", "pinyinDetails": "masculin", "numeric": "ta1", "fr": "il" },
+  { "id": "20", "series": 2, "hanzi": "她", "pinyin": "tā", "pinyinDetails": "feminin", "numeric": "ta1", "fr": "elle" },
   { "id": "21", "series": 2, "hanzi": "姓", "pinyin": "xìng", "numeric": "xing4", "fr": "nom","frDetails":"de famille" },
   { "id": "22", "series": 2, "hanzi": "中", "pinyin": "zhōng", "numeric": "zhong1", "fr": "milieu" },
   { "id": "23", "series": 2, "hanzi": "字", "pinyin": "zì", "numeric": "zi4", "fr": "caractère" }

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -6,6 +6,7 @@ export type Word = {
   hanzi: string;
   pinyin: string;   // with tones
   numeric: string;  //  ni3 hao3
+  pinyinDetails?: string;
   fr: string;
   frDetails?: string;
   audioUrl?: string;


### PR DESCRIPTION
## Summary
- support optional `pinyinDetails` in word data
- display pinyin explanations in modules 1 and 3
- rename existing word entries to use `pinyinDetails`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit` (fails: Type errors)


------
https://chatgpt.com/codex/tasks/task_e_68a70b66d1488326abfcee5d7e083d90