### PR TITLE
feat: add piper tts example

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,12 @@ AsyncStorage used for cache & history
 LRU logic in separate utility (lib/lruCache.ts)
 
 Data & audio loading in lib/data.ts and lib/audio.ts
+## Example: generate Chinese speech with Piper
+
+1. Start a Piper HTTP server with a Mandarin voice on port 5002.
+2. Run the helper script:
+   ```bash
+   node scripts/piper-example.js "你好，世界"
+   ```
+3. The audio will be saved to `piper-output.wav` in the project root.
+

--- a/scripts/piper-example.js
+++ b/scripts/piper-example.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+const fs = require('fs');
+
+async function main() {
+  const text = process.argv[2] || '你好，世界';
+  const response = await fetch('http://localhost:5002/api/tts', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`HTTP ${response.status}: ${errorText}`);
+  }
+
+  const audioBuffer = Buffer.from(await response.arrayBuffer());
+  const outFile = 'piper-output.wav';
+  fs.writeFileSync(outFile, audioBuffer);
+  console.log(`Saved TTS audio to ${outFile}`);
+}
+
+main().catch((err) => {
+  console.error('Error:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add Node script demonstrating how to call a local Piper HTTP server
- document how to run the example and save audio output

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a474df2a8483268013431da829196e