### PR TITLE
feat: modernize theme and home layout

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -72,8 +72,8 @@ export default function HomeScreen() {
         <Text style={[styles.title, { color: colors.text, fontSize: tx(20) }]}>
           Réviser le chinois
         </Text>
-        <Text style={[styles.subtitle, { color: colors.muted, fontSize: tx(13) }]}>
-          Minimaliste & Zen
+        <Text style={[styles.subtitle, { color: colors.muted, fontSize: tx(13) }]}> 
+          Apprentissage moderne et motivant
         </Text>
       </View>
 
@@ -82,10 +82,30 @@ export default function HomeScreen() {
 
       {/* Actions */}
       <View style={styles.actions}>
-        <ZenButton title="Cours" onPress={go("/module/4")} />
-        <ZenButton title="Dictionnaire" onPress={go("/module/2", "Bravo !")} />
-        <ZenButton title="Exercices" onPress={go("/module/1/settings", "Dommage…")} />
-        <ZenButton title="Écriture" onPress={go("/module/3/settings")} />
+        <ZenButton
+          title="Cours"
+          icon="school-outline"
+          onPress={go("/module/4")}
+          style={styles.actionBtn}
+        />
+        <ZenButton
+          title="Dictionnaire"
+          icon="book-outline"
+          onPress={go("/module/2", "Bravo !")}
+          style={styles.actionBtn}
+        />
+        <ZenButton
+          title="Exercices"
+          icon="game-controller-outline"
+          onPress={go("/module/1/settings", "Dommage…")}
+          style={styles.actionBtn}
+        />
+        <ZenButton
+          title="Écriture"
+          icon="pencil-outline"
+          onPress={go("/module/3/settings")}
+          style={styles.actionBtn}
+        />
       </View>
 
       {/* Footer */}
@@ -139,7 +159,8 @@ const styles = StyleSheet.create({
   logoText: { fontWeight: "900" },
   title: { fontWeight: "800" },
   subtitle: {},
-  actions: { gap: 12, marginTop: 8 },
+  actions: { flexDirection: "row", flexWrap: "wrap", gap: 12, marginTop: 8 },
+  actionBtn: { flexBasis: "48%" },
   footer: {
     marginTop: "auto",
     paddingTop: 12,

--- a/components/ZenButton.tsx
+++ b/components/ZenButton.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { Pressable, StyleSheet, Text, View } from "react-native";
+import { Pressable, StyleSheet, Text, View, type StyleProp, type ViewStyle } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
 import { useTheme } from "../hooks/useTheme";
 
 type Props = {
@@ -7,9 +8,11 @@ type Props = {
   onPress?: () => void;
   disabled?: boolean;
   testID?: string;
+  icon?: React.ComponentProps<typeof Ionicons>["name"];
+  style?: StyleProp<ViewStyle>;
 };
 
-export const ZenButton: React.FC<Props> = ({ title, onPress, disabled, testID }) => {
+export const ZenButton: React.FC<Props> = ({ title, onPress, disabled, testID, icon, style }) => {
   const { colors, tx } = useTheme();
   return (
     <Pressable
@@ -19,17 +22,20 @@ export const ZenButton: React.FC<Props> = ({ title, onPress, disabled, testID })
       style={({ pressed }) => [
         styles.button,
         {
-          backgroundColor: colors.card,
-          borderColor: colors.border,
-          transform: [{ scale: pressed ? 0.98 : 1 }],
+          backgroundColor: colors.accent,
+          transform: [{ scale: pressed ? 0.97 : 1 }],
           shadowColor: "#000",
         },
         disabled && { opacity: 0.5 },
+        style,
       ]}
     >
       <View style={styles.row}>
-        <Text style={[styles.title, { color: colors.text, fontSize: tx(16) }]}>{title}</Text>
-        <Text style={[styles.chevron, { color: colors.accent, fontSize: tx(20) }]}>›</Text>
+        <View style={styles.left}>
+          {icon && <Ionicons name={icon} size={tx(18)} color="#fff" />}
+          <Text style={[styles.title, { color: "#fff", fontSize: tx(16) }]}>{title}</Text>
+        </View>
+        <Ionicons name="chevron-forward" size={tx(20)} color="#fff" />
       </View>
     </Pressable>
   );
@@ -40,13 +46,13 @@ const styles = StyleSheet.create({
     paddingVertical: 16,
     paddingHorizontal: 18,
     borderRadius: 16,
-    borderWidth: 1,
+    borderWidth: 0,
     shadowOpacity: 0.06,
     shadowRadius: 10,
     shadowOffset: { width: 0, height: 3 },
     elevation: 2,
   },
   row: { flexDirection: "row", alignItems: "center", justifyContent: "space-between" },
+  left: { flexDirection: "row", alignItems: "center", gap: 8 },
   title: { fontWeight: "700" },
-  chevron: { fontWeight: "800" },
 });

--- a/constants/Colors.ts
+++ b/constants/Colors.ts
@@ -3,24 +3,25 @@
  * There are many other ways to style your app. For example, [Nativewind](https://www.nativewind.dev/), [Tamagui](https://tamagui.dev/), [unistyles](https://reactnativeunistyles.vercel.app), etc.
  */
 
-const tintColorLight = '#0a7ea4';
-const tintColorDark = '#fff';
+// Refresh the default Expo color palette to match the new app theme
+const tintColorLight = '#3B82F6';
+const tintColorDark = '#60A5FA';
 
 export const Colors = {
   light: {
-    text: '#11181C',
-    background: '#fff',
+    text: '#1F2937',
+    background: '#F5F7FA',
     tint: tintColorLight,
-    icon: '#687076',
-    tabIconDefault: '#687076',
+    icon: '#6B7280',
+    tabIconDefault: '#6B7280',
     tabIconSelected: tintColorLight,
   },
   dark: {
-    text: '#ECEDEE',
-    background: '#151718',
+    text: '#F9FAFB',
+    background: '#1F2937',
     tint: tintColorDark,
-    icon: '#9BA1A6',
-    tabIconDefault: '#9BA1A6',
+    icon: '#9CA3AF',
+    tabIconDefault: '#9CA3AF',
     tabIconSelected: tintColorDark,
   },
 };

--- a/constants/theme.ts
+++ b/constants/theme.ts
@@ -4,20 +4,20 @@ export type UIMode = "light" | "dark";
 
 export const THEME_COLORS = {
   light: {
-    background: "#FDFBF7", // crème
-    text: "#111111",
-    muted: "#5A5A5A",
+    background: "#F5F7FA",
+    text: "#1F2937",
+    muted: "#6B7280",
     card: "#FFFFFF",
-    border: "rgba(0,0,0,.06)",
-    accent: "#1AA890", // jade
+    border: "#E5E7EB",
+    accent: "#3B82F6",
   },
   dark: {
-    background: "#000000", // noir
-    text: "#FFFFFF",
-    muted: "#D0D0D0",
-    card: "#111111",
-    border: "rgba(255,255,255,.12)",
-    accent: "#FFFFFF", // pas de couleur en sombre
+    background: "#1F2937",
+    text: "#F9FAFB",
+    muted: "#D1D5DB",
+    card: "#374151",
+    border: "#4B5563",
+    accent: "#60A5FA",
   },
 } as const;
 


### PR DESCRIPTION
## Summary
- refresh light and dark color palettes with vibrant blue accents
- redesign ZenButton to support icons and accent styling
- reorganize home screen actions into a modern two-column grid

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a82d7d69948326833c591b0119e75d